### PR TITLE
fixing offline schedule; boneheaded error <sigh>

### DIFF
--- a/device/seestar_imaging.py
+++ b/device/seestar_imaging.py
@@ -1,0 +1,34 @@
+#
+# seestar_imaging - performances image-related tasks with a Seestar
+#
+# This is just the beginning
+#
+
+
+class SeestarImaging:
+    def __new__(cls, *args, **kwargs):
+        return super().__new__(cls)
+
+    def __init__(self, logger, host, port, device_name, device_num):
+        logger.info(f"Initialize new instance of Seestar imager: {host}:{port}, name:{device_name}")
+
+        self.host = host
+        self.port = port
+        self.device_name = device_name
+        self.device_num = device_num
+        self.logger = logger
+
+    def __repr__(self):
+        return f"{type(self).__name__}(host={self.host}, port={self.port})"
+
+    def reconnect(self):
+        pass
+
+    def disconnect(self):
+        pass
+
+    def send_message(self, data):
+        pass
+
+    def receive_message(self):
+        pass

--- a/front/app.py
+++ b/front/app.py
@@ -616,7 +616,7 @@ def render_schedule_tab(req, resp, telescope_id, template_name, tab, values, err
         current = do_action_device("get_schedule", telescope_id, {})
         schedule = current["Value"]
     else:
-        schedule = { list: get_queue(telescope_id) }
+        schedule = { "list": get_queue(telescope_id) }
 
     if(Config.twilighttimes):
         twilight_times = get_twilight_times()
@@ -739,7 +739,7 @@ class ImageResource:
             schedule = current["Value"]
         else:
             state = "Stopped"
-            schedule = { list: get_queue(telescope_id) }
+            schedule = { "list": get_queue(telescope_id) }
         context = get_context(telescope_id, req)
         # remove values=values to stop remembering values
         render_template(req, resp, 'image.html', state=state, schedule=schedule, values=values, errors=errors,
@@ -761,7 +761,7 @@ class CommandResource:
             state = current["Value"]["state"]
             schedule = current["Value"]
         else:
-            schedule = { list: get_queue(telescope_id) }
+            schedule = { "list": get_queue(telescope_id) }
             state = "Stopped"
 
         context = get_context(telescope_id, req)
@@ -786,7 +786,7 @@ class MosaicResource:
             schedule = current["Value"]
         else:
             state = "Stopped"
-            schedule = { list: get_queue(telescope_id) }
+            schedule = { "list": get_queue(telescope_id) }
         context = get_context(telescope_id, req)
         # remove values=values to stop remembering values
         render_template(req, resp, 'mosaic.html', state=state, schedule=schedule, values=values, errors=errors,
@@ -810,7 +810,7 @@ class ScheduleListResource:
             current = do_action_device("get_schedule", telescope_id, {})
             schedule = current["Value"]
         else:
-            schedule = {list: get_queue(telescope_id)}
+            schedule = {"list": get_queue(telescope_id)}
 
         context = get_context(telescope_id, req)
         render_template(req, resp, 'schedule_list.html', schedule=schedule, **context)


### PR DESCRIPTION
Used Typescript-type map definition syntax, which while syntacically correct in Python did not produce desired result.   Broke display of offline schedules.

Also placeholder for new image module.
